### PR TITLE
optionally give instances custom names

### DIFF
--- a/.changeset/mean-ears-cry.md
+++ b/.changeset/mean-ears-cry.md
@@ -1,0 +1,5 @@
+---
+"pumpit": minor
+---
+
+Optionally give instances custom names.

--- a/src/__tests__/pumpit.test.ts
+++ b/src/__tests__/pumpit.test.ts
@@ -255,4 +255,19 @@ describe("Optional injection", () => {
     expect(instance.a).toBeInstanceOf(TestA)
     expect(instance.bd).toBeInstanceOf(TestB)
   })
+
+  describe("instance name", () => {
+    test("instance name can be passed via constructor", () => {
+      const name = "instance_name"
+      const pumpIt = new PumpIt(name)
+
+      expect(pumpIt.getName()).toBe(name)
+    })
+
+    test("if instance name is not provided it will be undefined", () => {
+      const pumpIt = new PumpIt()
+
+      expect(pumpIt.getName()).toBe(undefined)
+    })
+  })
 })

--- a/src/pumpit.ts
+++ b/src/pumpit.ts
@@ -49,6 +49,16 @@ export class PumpIt {
 
   protected currentCtx: RequestCtx | null = null
 
+  protected name?: string
+
+  constructor(name?: string) {
+    this.name = name
+  }
+
+  getName() {
+    return this.name
+  }
+
   protected add(key: BindKey, value: any, info: PoolData): void {
     const dataHit = this.pool.get(key)
 


### PR DESCRIPTION
This PR makes possible to give every `Pumpit` instance a custom name.