### PR TITLE
ci: bump checkout and setup-node to v7

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,7 +21,7 @@ jobs:
         node: [ '24']
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -32,7 +32,7 @@ jobs:
           run_install: false
 
       - name: Setup node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node }}
           cache: pnpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       publish-plan-artifact-id: ${{ steps.select-mode.outputs.publish-plan-artifact-id }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -32,7 +32,7 @@ jobs:
           run_install: false
 
       - name: Setup node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v7
         with:
           node-version: '24'
           cache: pnpm
@@ -54,7 +54,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -65,7 +65,7 @@ jobs:
           run_install: false
 
       - name: Setup node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v7
         with:
           node-version: '24'
           cache: pnpm
@@ -92,7 +92,7 @@ jobs:
       pack-dir-artifact-id: ${{ steps.pack.outputs.pack-dir-artifact-id }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -103,7 +103,7 @@ jobs:
           run_install: false
 
       - name: Setup node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v7
         with:
           node-version: '24'
           cache: pnpm
@@ -142,7 +142,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -153,7 +153,7 @@ jobs:
           run_install: false
 
       - name: Setup node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v7
         with:
           node-version: '24'
           cache: pnpm


### PR DESCRIPTION
Follow-up to #128, which pinned `actions/checkout@v5` and `actions/setup-node@v5`. Both are two majors behind.

Neither major affects this repo:

- **checkout v6 → v7** — v6 moved credentials to a separate file; v7 blocks fork checkouts for `pull_request_target`/`workflow_run` and migrated to ESM. Both workflows pass `persist-credentials: false` and use neither trigger.
- **setup-node v6 → v7** — v6 [limited *automatic* caching to npm](https://github.com/actions/setup-node/pull/1374), but explicit `cache: pnpm` is still supported (`action.yml` lists `npm, yarn, pnpm`). v7 is ESM plus the removal of the dummy `NODE_AUTH_TOKEN` export, which is welcome now that publishing goes through OIDC.

`pnpm/action-setup` stays at v4.4.0 for now. It's deprecated in favour of [`pnpm/setup`](https://github.com/pnpm/setup), which is a larger change than a version bump — it subsumes `setup-node` and the install step, and installs Node via `pnpm runtime set` rather than the tool cache. `pnpm/setup@v2` is also only days old. Worth doing, separately.

Note this only exercises `CI.yml`; the `release.yml` changes are identical but can't run until they're on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)